### PR TITLE
Update TpllCommand.java

### DIFF
--- a/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
+++ b/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
@@ -121,8 +121,6 @@ public class TpllCommand implements CommandExecutor {
 
             World tpWorld = player.getWorld();
 
-            int xOffset = Terraplusminus.config.getInt("terrain_offset.x");
-            int zOffset = Terraplusminus.config.getInt("terrain_offset.z");
             double minLat = Terraplusminus.config.getDouble("min_latitude");
             double maxLat = Terraplusminus.config.getDouble("max_latitude");
             double minLon = Terraplusminus.config.getDouble("min_longitude");
@@ -179,8 +177,8 @@ public class TpllCommand implements CommandExecutor {
                         tpWorld = Bukkit.getWorld(nextServer.getWorldName());
                         height = height - yOffset + nextServer.getOffset();
                         player.sendMessage(Terraplusminus.config.getString("prefix") + "§7Teleporting to " + coordinates[1] + ", " + coordinates[0] + " in another world. This may take a bit...");
-                        //player.teleport(new Location(tpWorld, mcCoordinates[0] + xOffset, height, mcCoordinates[1] + zOffset, player.getLocation().getYaw(), player.getLocation().getPitch()));
-                        PaperLib.teleportAsync(player, new Location(tpWorld, mcCoordinates[0] + xOffset, height, mcCoordinates[1] + zOffset, player.getLocation().getYaw(), player.getLocation().getPitch()));
+                        //player.teleport(new Location(tpWorld, mcCoordinates[0], height, mcCoordinates[1], player.getLocation().getYaw(), player.getLocation().getPitch()));
+                        PaperLib.teleportAsync(player, new Location(tpWorld, mcCoordinates[0], height, mcCoordinates[1], player.getLocation().getYaw(), player.getLocation().getPitch()));
                         return true;
                     }
                 } else {
@@ -201,7 +199,7 @@ public class TpllCommand implements CommandExecutor {
                         tpWorld = Bukkit.getWorld(previousServer.getWorldName());
                         height = height - yOffset + previousServer.getOffset();
                         player.sendMessage(Terraplusminus.config.getString("prefix") + "§7Teleporting to " + coordinates[1] + ", " + coordinates[0] + " in another world. This may take a bit...");
-                        PaperLib.teleportAsync(player, new Location(tpWorld, mcCoordinates[0] + xOffset, height, mcCoordinates[1] + zOffset, player.getLocation().getYaw(), player.getLocation().getPitch()));
+                        PaperLib.teleportAsync(player, new Location(tpWorld, mcCoordinates[0], height, mcCoordinates[1], player.getLocation().getYaw(), player.getLocation().getPitch()));
                         return true;
                     }
                 } else {


### PR DESCRIPTION
Why apply offset again when it is already [applied](https://github.com/BTE-Germany/TerraPlusMinus/blob/4e18bc6ba5aff60998a039194584995f38a346fe/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java#L70C1-L70C1)

Also this causes a chunk system error when the offset is not `(0, 0, 0)`
```
[16:58:48] [Tuinity Chunk System Worker #2/ERROR]: [ChunkTaskScheduler] Chunk system error at chunk (~~~,~~~), holder: NewChunkHolder{world=~~~, chunkX=~~~, chunkZ=~~~, entityChunkFromDisk=false, lastChunkCompletion={chunk_class=net.minecraft.world.level.chunk.ProtoChunk,status=minecraft:structure_references}, currentGenStatus=minecraft:structure_references, requestedGenStatus=minecraft:full, generationTask=ChunkProgressionTask{class: io.papermc.paper.chunk.system.scheduling.ChunkUpgradeGenericStatusTask, for world: ~~~, chunk: (~~~,~~~), hashcode: 1779680793, priority: COMPLETING, status: minecraft:biomes, scheduled: true}, generationTaskStatus=minecraft:biomes, priority=HIGHER, priorityLocked=false, neighbourRequestedPriority=IDLE, effective_priority=HIGHER, oldTicketLevel=33, currentTicketLevel=33, totalNeighboursUsingThisChunk=4, fullNeighbourChunksLoadedBitset=0, chunkStatusRaw=0, currentChunkStatus=INACCESSIBLE, pendingChunkStatus=INACCESSIBLE, is_unload_safe=ticket_level, killed=false}, exception:
java.lang.Throwable: java.util.concurrent.CompletionException: java.lang.RuntimeException: net.buildtheearth.terraminusminus.projection.OutOfProjectionBoundsException
	at io.papermc.paper.chunk.system.scheduling.ChunkTaskScheduler.unrecoverableChunkSystemFailure(ChunkTaskScheduler.java:279) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.NewChunkHolder.lambda$setGenerationTask$4(NewChunkHolder.java:1700) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.ChunkProgressionTask.complete0(ChunkProgressionTask.java:95) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.ChunkProgressionTask.complete(ChunkProgressionTask.java:75) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.ChunkUpgradeGenericStatusTask.run(ChunkUpgradeGenericStatusTask.java:139) ~[paper-1.20.4.jar:git-Paper-381]
	at ca.spottedleaf.concurrentutil.executor.standard.PrioritisedThreadedTaskQueue$PrioritisedTask.executeInternal(PrioritisedThreadedTaskQueue.java:351) ~[paper-1.20.4.jar:git-Paper-381]
	at ca.spottedleaf.concurrentutil.executor.standard.PrioritisedThreadedTaskQueue.executeTask(PrioritisedThreadedTaskQueue.java:118) ~[paper-1.20.4.jar:git-Paper-381]
	at ca.spottedleaf.concurrentutil.executor.standard.PrioritisedThreadPool$PrioritisedThread.pollTasks(PrioritisedThreadPool.java:274) ~[paper-1.20.4.jar:git-Paper-381]
	at ca.spottedleaf.concurrentutil.executor.standard.PrioritisedQueueExecutorThread.run(PrioritisedQueueExecutorThread.java:62) ~[paper-1.20.4.jar:git-Paper-381]
Caused by: java.util.concurrent.CompletionException: java.lang.RuntimeException: net.buildtheearth.terraminusminus.projection.OutOfProjectionBoundsException
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770) ~[?:?]
	at java.util.concurrent.CompletableFuture.asyncSupplyStage(CompletableFuture.java:1782) ~[?:?]
	at java.util.concurrent.CompletableFuture.supplyAsync(CompletableFuture.java:2005) ~[?:?]
	at net.minecraft.world.level.chunk.ChunkGenerator.createBiomes(ChunkGenerator.java:114) ~[paper-1.20.4.jar:git-Paper-381]
	at net.minecraft.world.level.chunk.ChunkStatus.lambda$static$6(ChunkStatus.java:84) ~[paper-1.20.4.jar:git-Paper-381]
	at net.minecraft.world.level.chunk.ChunkStatus.generate(ChunkStatus.java:259) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.ChunkUpgradeGenericStatusTask.run(ChunkUpgradeGenericStatusTask.java:86) ~[paper-1.20.4.jar:git-Paper-381]
	... 4 more
Caused by: java.lang.RuntimeException: net.buildtheearth.terraminusminus.projection.OutOfProjectionBoundsException
	at de.btegermany.terraplusminus.data.TerraConnector.toGeo(TerraConnector.java:31) ~[terraplusminus-1.3.2.jar:?]
	at de.btegermany.terraplusminus.gen.CustomBiomeProvider.getBiome(CustomBiomeProvider.java:30) ~[terraplusminus-1.3.2.jar:?]
	at org.bukkit.generator.BiomeProvider.getBiome(BiomeProvider.java:61) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R3.generator.CustomWorldChunkManager.getNoiseBiome(CustomWorldChunkManager.java:47) ~[paper-1.20.4.jar:git-Paper-381]
	at net.minecraft.world.level.chunk.LevelChunkSection.fillBiomesFromNoise(LevelChunkSection.java:235) ~[?:?]
	at net.minecraft.world.level.chunk.ChunkAccess.fillBiomesFromNoise(ChunkAccess.java:535) ~[?:?]
	at net.minecraft.world.level.chunk.ChunkGenerator.lambda$createBiomes$3(ChunkGenerator.java:115) ~[paper-1.20.4.jar:git-Paper-381]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at java.util.concurrent.CompletableFuture.asyncSupplyStage(CompletableFuture.java:1782) ~[?:?]
	at java.util.concurrent.CompletableFuture.supplyAsync(CompletableFuture.java:2005) ~[?:?]
	at net.minecraft.world.level.chunk.ChunkGenerator.createBiomes(ChunkGenerator.java:114) ~[paper-1.20.4.jar:git-Paper-381]
	at net.minecraft.world.level.chunk.ChunkStatus.lambda$static$6(ChunkStatus.java:84) ~[paper-1.20.4.jar:git-Paper-381]
	at net.minecraft.world.level.chunk.ChunkStatus.generate(ChunkStatus.java:259) ~[paper-1.20.4.jar:git-Paper-381]
	at io.papermc.paper.chunk.system.scheduling.ChunkUpgradeGenericStatusTask.run(ChunkUpgradeGenericStatusTask.java:86) ~[paper-1.20.4.jar:git-Paper-381]
	... 4 more
```