### PR TITLE
1.21.4 chunk generation crash fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
             <id>OpenCollab Snapshots</id>
             <url>https://repo.opencollab.dev/snapshot/</url>
         </repository>
-            <repository>
-                <id>jitpack.io</id>
-                <url>https://jitpack.io</url>
-            </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
         <repository>
             <id>Daporkchop_</id>
             <url>https://maven.daporkchop.net/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
             <id>OpenCollab Snapshots</id>
             <url>https://repo.opencollab.dev/snapshot/</url>
         </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
+            <repository>
+                <id>jitpack.io</id>
+                <url>https://jitpack.io</url>
+            </repository>
         <repository>
             <id>Daporkchop_</id>
             <url>https://maven.daporkchop.net/</url>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,9 +109,9 @@
             <version>2.8.9</version>
         </dependency>
         <dependency>
-            <groupId>com.github.BTEUK</groupId>
+            <groupId>com.github.SmylerMC</groupId>
             <artifactId>terraminusminus</artifactId>
-            <version>22449a34bf</version>
+            <version>c6d983e221</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
@@ -197,11 +197,15 @@ public class RealWorldGenerator extends ChunkGenerator {
                 } else {
                     // Fallback to a generic block that matches the biome
                     Biome biome = chunkData.getBiome(x, groundY, z);
-                    material = switch (biome) {
-                        case DESERT -> Material.SAND;
-                        case SNOWY_SLOPES, SNOWY_PLAINS, FROZEN_PEAKS -> SNOW_BLOCK;
-                        default -> this.surfaceMaterial;
-                    };
+                    if (biome.name().equals("DESERT")) {
+                        material = Material.SAND;
+                    } else if (biome.name().equals("SNOWY_SLOPES") ||
+                            biome.name().equals("SNOWY_PLAINS") ||
+                            biome.name().equals("FROZEN_PEAKS")) {
+                        material = Material.SNOW_BLOCK;
+                    } else {
+                        material = this.surfaceMaterial;
+                    }
                 }
 
                 // We don't want grass, snow, and all underwater


### PR DESCRIPTION
I updated my server to 1.21.4 and compiled the latest t+- version. However, when generating new chunks there was an error and a crash about `java.lang.IncompatibleClassChangeError: Method 'org.bukkit.block.Biome[] org.bukkit.block.Biome.values()' must be InterfaceMethodref constant`

Full log: https://pastebin.com/QUZK4cjs

I fixed the error by rewriting some stuff, primarily changing the paper api version and changing the switch statement, because the biome class was longer an enum and instead a interface. My bug fix doesn't seem to have created any issue so far, but since I have only basic knowledge of java, there are probably some bad practices somewhere so it would be great if some more experienced java programmers could take a look at it
