### PR TITLE
Enable concurrent requests for certain urls.

### DIFF
--- a/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
@@ -14,6 +14,7 @@ import net.buildtheearth.terraminusminus.projection.transform.OffsetProjectionTr
 import net.buildtheearth.terraminusminus.substitutes.BlockState;
 import net.buildtheearth.terraminusminus.substitutes.BukkitBindings;
 import net.buildtheearth.terraminusminus.substitutes.ChunkPos;
+import net.buildtheearth.terraminusminus.util.http.Http;
 import org.bukkit.HeightMap;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -73,6 +74,8 @@ public class RealWorldGenerator extends ChunkGenerator {
     );
 
     public RealWorldGenerator(int yOffset) {
+
+        Http.configChanged(); // This ensures the T-- default config is loaded regarding the number of concurrent http requests for specific urls.
 
         EarthGeneratorSettings settings = EarthGeneratorSettings.parse(EarthGeneratorSettings.BTE_DEFAULT_SETTINGS);
 


### PR DESCRIPTION
Ensures the T-- config for concurrent http requests is loaded, specifically for elevation data it allows 8 concurrent http requests instead of the default 1, testing shows that for a /tpll to a new area it can speed up the time it takes to load the terrain by over 25%.