### PR TITLE
fix: 🐛 correct offset handling + multiverse teleportation

### DIFF
--- a/src/main/java/de/btegermany/terraplusminus/events/PlayerMoveEvent.java
+++ b/src/main/java/de/btegermany/terraplusminus/events/PlayerMoveEvent.java
@@ -80,7 +80,7 @@ public class PlayerMoveEvent implements Listener {
 
     @EventHandler
     void onPlayerFall(org.bukkit.event.player.PlayerMoveEvent event) {
-        if (!this.linkedWorldsEnabled && !this.linkedWorldsMethod.equalsIgnoreCase(Properties.NonConfigurable.METHOD_MV)) {
+        if (!this.linkedWorldsEnabled || !this.linkedWorldsMethod.equalsIgnoreCase(Properties.NonConfigurable.METHOD_MV)) {
             return;
         }
 

--- a/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
@@ -221,6 +221,17 @@ public class RealWorldGenerator extends ChunkGenerator {
         }
     }
 
+    /**
+     * Gets Chunk Data async with the supplied chunk coordinates.
+     *
+     * @param chunkX The Chunk X coordinate
+     * @param chunkZ The Chunk Z coordinate
+     * @return A CompletableFuture containing the CachedChunkData
+     */
+    public CompletableFuture<CachedChunkData> getBaseHeightAsync(int chunkX, int chunkZ) {
+        return this.cache.getUnchecked(new ChunkPos(chunkX, chunkZ));
+    }
+
     @Override
     public int getBaseHeight(@NotNull WorldInfo worldInfo, @NotNull Random random, int x, int z, @NotNull HeightMap heightMap) {
         int chunkX = blockToCube(x);
@@ -236,12 +247,6 @@ public class RealWorldGenerator extends ChunkGenerator {
                 return terraData.surfaceHeight(x, z) + this.yOffset;
             }
         }
-    }
-
-    public CompletableFuture<CachedChunkData> getBaseHeightAsync(int x, int z) {
-        int chunkX = blockToCube(x);
-        int chunkZ = blockToCube(z);
-        return this.cache.getUnchecked(new ChunkPos(chunkX, chunkZ));
     }
 
     @Override


### PR DESCRIPTION
This resolves some issues:
- Multiple Offsets were wrongly added to the location
- You could only teleport to one world at a time (mv setup)
- The Method for getting the data async had a confusing name which had nor really reflected the usage 