### PR TITLE
Prime Terra cache before tpll teleports

### DIFF
--- a/src/main/java/de/btegermany/terraplusminus/Terraplusminus.java
+++ b/src/main/java/de/btegermany/terraplusminus/Terraplusminus.java
@@ -39,8 +39,10 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
+import static net.buildtheearth.terraminusminus.substitutes.ChunkPos.blockToCube;
 import static net.daporkchop.lib.common.util.PValidation.checkState;
 
 public final class Terraplusminus extends JavaPlugin implements Listener {
@@ -157,6 +159,68 @@ public final class Terraplusminus extends JavaPlugin implements Listener {
             yOffset = getConfig().getInt(Properties.Y_OFFSET);
         }
         return new RealWorldGenerator(yOffset, this);
+    }
+
+    /**
+     * Returns whether every chunk in the target teleport radius already exists on disk/in world data.
+     * This method is intentionally public so optional teleportation plugins can call it without
+     * Terraplusminus depending on them.
+     */
+    public boolean isTeleportRegionGenerated(@NotNull World world, double x, double z, int radiusChunks) {
+        if (!(world.getGenerator() instanceof RealWorldGenerator)) {
+            return true;
+        }
+
+        int centerChunkX = blockToCube(blockCoordinate(x));
+        int centerChunkZ = blockToCube(blockCoordinate(z));
+        int radius = Math.max(0, radiusChunks);
+
+        for (int chunkX = centerChunkX - radius; chunkX <= centerChunkX + radius; chunkX++) {
+            for (int chunkZ = centerChunkZ - radius; chunkZ <= centerChunkZ + radius; chunkZ++) {
+                if (!world.isChunkGenerated(chunkX, chunkZ)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Primes Terra-- chunk data for the requested teleport region when the world uses Terraplusminus.
+     * Non-Terraplusminus worlds complete immediately so this API is safe for optional integrations.
+     */
+    public @NotNull CompletableFuture<Void> primeTeleportRegionCache(@NotNull World world, double x, double z, int radiusChunks) {
+        if (!(world.getGenerator() instanceof RealWorldGenerator generator)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        int centerChunkX = blockToCube(blockCoordinate(x));
+        int centerChunkZ = blockToCube(blockCoordinate(z));
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(this, () ->
+                generator.primeCache(centerChunkX, centerChunkZ, radiusChunks)
+                        .whenComplete((unused, throwable) -> {
+                            if (throwable != null) {
+                                result.completeExceptionally(throwable);
+                                return;
+                            }
+                            result.complete(null);
+                        }));
+        return result;
+    }
+
+    /**
+     * Prepares a teleport target region and returns true when the region was already generated.
+     */
+    public @NotNull CompletableFuture<Boolean> prepareTeleportRegion(@NotNull World world, double x, double z, int radiusChunks) {
+        if (this.isTeleportRegionGenerated(world, x, z, radiusChunks)) {
+            return CompletableFuture.completedFuture(true);
+        }
+        return this.primeTeleportRegionCache(world, x, z, radiusChunks).thenApply(unused -> false);
+    }
+
+    private static int blockCoordinate(double coordinate) {
+        return (int) Math.floor(coordinate);
     }
 
 

--- a/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
+++ b/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
@@ -64,6 +64,7 @@ public class TpllCommand {
     // <editor-fold desc="Constants and Fields">
     public static final String LAT_LON_HEIGHT = "latLonHeight";
     public static final String TPLL_OTHERS_PERMISSION = "t+-.forcetpll";
+    private static final int TELEPORT_PREP_RADIUS_CHUNKS = 16;
 
     static String prefix;
     // </editor-fold>
@@ -151,11 +152,13 @@ public class TpllCommand {
 
         if (!config.getBoolean(Properties.LINKED_WORLDS_ENABLED) && latLngHeight.height() == null) {
             Terraplusminus.instance.getComponentLogger().debug("Fetching elevation from Heightmap...");
-            finalizeTeleport(target,
-                    tpWorld,
-                    new Vector(x, tpWorld.getHighestBlockYAt((int) x, (int) z) + 1d, z),
-                    latLngHeight.latLng(),
-                    yOffset);
+            World finalTpWorld = tpWorld;
+            prepareTeleportRegion(target, finalTpWorld, x, z, () ->
+                    finalizeTeleport(target,
+                            finalTpWorld,
+                            new Vector(x, finalTpWorld.getHighestBlockYAt((int) x, (int) z) + 1d, z),
+                            latLngHeight.latLng(),
+                            yOffset));
             return;
         }
 
@@ -173,21 +176,26 @@ public class TpllCommand {
             int chunkX = ChunkPos.blockToCube(roundedX);
             int chunkZ = ChunkPos.blockToCube(roundedZ);
             World finalTpWorld = tpWorld;
-            terraGenerator.getBaseHeightAsync(chunkX, chunkZ)
-                    .thenAcceptAsync(baseHeight ->
-                            finalizeTeleport(target,
-                                    finalTpWorld,
-                                    new Vector(x, baseHeight.surfaceHeight(roundedX - ChunkPos.cubeToMinBlock(chunkX),
-                                            roundedZ - ChunkPos.cubeToMinBlock(chunkZ)) + yOffset + 1d, z),
-                                    latLngHeight.latLng(),
-                                    yOffset
-                            )).exceptionally(ex -> {
-                        target.sendMessage(RED + "Error while fetching elevation from API!");
-                        Terraplusminus.instance.getComponentLogger().error("Error while fetching elevation from API for tpll!", ex);
-                        return null;
-                    });
+            RealWorldGenerator finalTerraGenerator = terraGenerator;
+            prepareTeleportRegion(target, finalTpWorld, x, z, () ->
+                    finalTerraGenerator.getBaseHeightAsync(chunkX, chunkZ)
+                            .thenAccept(baseHeight -> Bukkit.getScheduler().runTask(Terraplusminus.instance, () ->
+                                    finalizeTeleport(target,
+                                            finalTpWorld,
+                                            new Vector(x, baseHeight.surfaceHeight(roundedX - ChunkPos.cubeToMinBlock(chunkX),
+                                                    roundedZ - ChunkPos.cubeToMinBlock(chunkZ)) + yOffset + 1d, z),
+                                            latLngHeight.latLng(),
+                                            yOffset
+                                    ))).exceptionally(ex -> {
+                                Bukkit.getScheduler().runTask(Terraplusminus.instance, () ->
+                                        target.sendMessage(RED + "Error while fetching elevation from API!"));
+                                Terraplusminus.instance.getComponentLogger().error("Error while fetching elevation from API for tpll!", ex);
+                                return null;
+                            }));
         } else {
-            finalizeTeleport(target, tpWorld, new Vector(x, latLngHeight.height() + yOffset, z), latLngHeight.latLng(), yOffset);
+            World finalTpWorld = tpWorld;
+            prepareTeleportRegion(target, finalTpWorld, x, z, () ->
+                    finalizeTeleport(target, finalTpWorld, new Vector(x, latLngHeight.height() + yOffset, z), latLngHeight.latLng(), yOffset));
         }
     }
 
@@ -245,12 +253,14 @@ public class TpllCommand {
                 return;
             }
 
-            target.sendMessage(prefix + "§7Teleporting to linked world...");
-            target.teleportAsync(new Location(linkedWorld, mcCoords.getX(), newHeight, mcCoords.getZ(), target.getLocation().getYaw(), target.getLocation().getPitch()))
-                    .thenAcceptAsync(success -> {
-                        if (Boolean.TRUE.equals(success))
-                            target.sendMessage(prefix + "§7Teleported to " + geoCoords.getLat() + ", " + geoCoords.getLng() + ", " + (mcCoords.getBlockY() - yOff) + ".");
-                    });
+            prepareTeleportRegion(target, linkedWorld, mcCoords.getX(), mcCoords.getZ(), () -> {
+                target.sendMessage(prefix + "§7Teleporting to linked world...");
+                target.teleportAsync(new Location(linkedWorld, mcCoords.getX(), newHeight, mcCoords.getZ(), target.getLocation().getYaw(), target.getLocation().getPitch()))
+                        .thenAcceptAsync(success -> {
+                            if (Boolean.TRUE.equals(success))
+                                target.sendMessage(prefix + "§7Teleported to " + geoCoords.getLat() + ", " + geoCoords.getLng() + ", " + (mcCoords.getBlockY() - yOff) + ".");
+                        });
+            });
         }
     }
 
@@ -312,6 +322,23 @@ public class TpllCommand {
             }
         }
         return false;
+    }
+
+    private static void prepareTeleportRegion(@NotNull Player target, @NotNull World world, double x, double z, @NotNull Runnable teleportAction) {
+        if (Terraplusminus.instance.isTeleportRegionGenerated(world, x, z, TELEPORT_PREP_RADIUS_CHUNKS)) {
+            teleportAction.run();
+            return;
+        }
+
+        target.sendMessage(prefix + "§7The target region is currently being generated. You will be teleported once it is ready.");
+        Terraplusminus.instance.primeTeleportRegionCache(world, x, z, TELEPORT_PREP_RADIUS_CHUNKS)
+                .thenRun(() -> Bukkit.getScheduler().runTask(Terraplusminus.instance, teleportAction))
+                .exceptionally(ex -> {
+                    Terraplusminus.instance.getComponentLogger().error("Failed to prepare tpll target region.", ex);
+                    Bukkit.getScheduler().runTask(Terraplusminus.instance, () ->
+                            target.sendMessage(prefix + RED + "Failed to generate the target region. Please try again later."));
+                    return null;
+                });
     }
     // </editor-fold>
 

--- a/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/RealWorldGenerator.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -51,8 +52,14 @@ public class RealWorldGenerator extends ChunkGenerator {
     @Getter
     private final int yOffset;
 
+    private static final int CHUNK_DATA_MAX_ATTEMPTS = 3;
+    private static final long CHUNK_DATA_RETRY_DELAY_MILLIS = 500L;
+    private static final int PRIME_CACHE_CONCURRENCY = 4;
+
+    private final Terraplusminus plugin;
     private final LoadingCache<@NotNull ChunkPos, @NotNull CompletableFuture<CachedChunkData>> cache;
     private final CustomBiomeProvider customBiomeProvider;
+    private final List<BlockPopulator> defaultPopulators;
 
 
     private final BlockData defaultSurfaceBlock;
@@ -75,6 +82,7 @@ public class RealWorldGenerator extends ChunkGenerator {
     );
 
     public RealWorldGenerator(int yOffset, Terraplusminus plugin) {
+        this.plugin = plugin;
 
         Http.configChanged(); // This ensures the T-- default config is loaded regarding the number of concurrent http requests for specific urls.
 
@@ -98,6 +106,7 @@ public class RealWorldGenerator extends ChunkGenerator {
                 .expireAfterAccess(5L, TimeUnit.MINUTES)
                 .softValues()
                 .build(new ChunkDataLoader(this.settings));
+        this.defaultPopulators = singletonList(new TreePopulator(this.customBiomeProvider, this.yOffset, this::getChunkDataAsync));
 
         // This code is explicitly there for backward compatibility and is legitimate in using the deprecated config keys
         this.blockMapper = BlockMapper.fromPlugin(plugin)
@@ -158,15 +167,14 @@ public class RealWorldGenerator extends ChunkGenerator {
 
                 int groundY = terraData.groundHeight(x, z) + this.yOffset;
 
-                // We do that for each column, so it does not depend on the configuration but only on the seed
-                int startMountainHeight = random.nextInt(7500, 7520);
-
                 if (groundY < minWorldY || groundY >= maxWorldY) {
                     continue; // We are not within vertical bounds, continue
                 }
 
                 BlockData surfaceBlock = this.blockMapper.map(terraData.surfaceBlock(x, z));
                 if (surfaceBlock == null) {
+                    // We do that for each column, so it does not depend on the configuration but only on the seed
+                    int startMountainHeight = random.nextInt(7500, 7520);
                     if (groundY >= startMountainHeight) {
                         surfaceBlock = this.mountainSurfaceBlock; // Mountains stay bare
                     } else {
@@ -190,8 +198,11 @@ public class RealWorldGenerator extends ChunkGenerator {
 
     private CachedChunkData getTerraChunkData(int chunkX, int chunkZ) {
         try {
-            return this.cache.getUnchecked(new ChunkPos(chunkX, chunkZ)).get();
-        } catch (InterruptedException | ExecutionException e) {
+            return this.getChunkDataAsync(new ChunkPos(chunkX, chunkZ)).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted when generating chunk data asynchronously in Terra--", e);
+        } catch (ExecutionException e) {
             throw new RuntimeException("Unrecoverable exception when generating chunk data asynchronously in Terra--", e);
         }
     }
@@ -204,7 +215,92 @@ public class RealWorldGenerator extends ChunkGenerator {
      * @return A CompletableFuture containing the CachedChunkData
      */
     public CompletableFuture<CachedChunkData> getBaseHeightAsync(int chunkX, int chunkZ) {
-        return this.cache.getUnchecked(new ChunkPos(chunkX, chunkZ));
+        return this.getChunkDataAsync(new ChunkPos(chunkX, chunkZ));
+    }
+
+    /**
+     * Starts loading Terra-- data for a square chunk radius around a target chunk.
+     * The returned future completes when all requested chunk data is present in the cache.
+     */
+    public CompletableFuture<Void> primeCache(int centerChunkX, int centerChunkZ, int radiusChunks) {
+        int radius = Math.max(0, radiusChunks);
+        CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
+        List<ChunkPos> batch = new ArrayList<>(PRIME_CACHE_CONCURRENCY);
+        for (int chunkX = centerChunkX - radius; chunkX <= centerChunkX + radius; chunkX++) {
+            for (int chunkZ = centerChunkZ - radius; chunkZ <= centerChunkZ + radius; chunkZ++) {
+                batch.add(new ChunkPos(chunkX, chunkZ));
+                if (batch.size() >= PRIME_CACHE_CONCURRENCY) {
+                    result = this.appendPrimeBatch(result, batch);
+                    batch = new ArrayList<>(PRIME_CACHE_CONCURRENCY);
+                }
+            }
+        }
+        if (!batch.isEmpty()) {
+            result = this.appendPrimeBatch(result, batch);
+        }
+        return result;
+    }
+
+    private CompletableFuture<Void> appendPrimeBatch(CompletableFuture<Void> previous, List<ChunkPos> batch) {
+        List<ChunkPos> chunkBatch = List.copyOf(batch);
+        return previous.thenCompose(unused -> CompletableFuture.allOf(
+                chunkBatch.stream()
+                        .map(chunkPos -> this.getChunkDataAsync(chunkPos).thenApply(data -> null))
+                        .toArray(CompletableFuture[]::new)
+        ));
+    }
+
+    private CompletableFuture<CachedChunkData> getChunkDataAsync(ChunkPos chunkPos) {
+        return this.getChunkDataAsync(chunkPos, 1);
+    }
+
+    private CompletableFuture<CachedChunkData> getChunkDataAsync(ChunkPos chunkPos, int attempt) {
+        CompletableFuture<CachedChunkData> future;
+        try {
+            future = this.cache.getUnchecked(chunkPos);
+        } catch (RuntimeException e) {
+            return this.retryChunkData(chunkPos, attempt, e);
+        }
+
+        return future.handle((data, throwable) -> {
+            if (throwable == null) {
+                return CompletableFuture.completedFuture(data);
+            }
+            return this.retryChunkData(chunkPos, attempt, throwable);
+        }).thenCompose(result -> result);
+    }
+
+    private CompletableFuture<CachedChunkData> retryChunkData(ChunkPos chunkPos, int attempt, Throwable throwable) {
+        this.cache.invalidate(chunkPos);
+        if (attempt >= CHUNK_DATA_MAX_ATTEMPTS) {
+            return CompletableFuture.failedFuture(throwable);
+        }
+
+        Throwable rootCause = unwrap(throwable);
+        this.plugin.getComponentLogger().warn(
+                "Terra-- chunk data load failed for chunk {}/{} on attempt {}/{}. Retrying in {} ms.",
+                chunkPos.x(),
+                chunkPos.z(),
+                attempt,
+                CHUNK_DATA_MAX_ATTEMPTS,
+                CHUNK_DATA_RETRY_DELAY_MILLIS,
+                rootCause
+        );
+
+        return CompletableFuture
+                .supplyAsync(
+                        () -> null,
+                        CompletableFuture.delayedExecutor(CHUNK_DATA_RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS)
+                )
+                .thenCompose(unused -> this.getChunkDataAsync(chunkPos, attempt + 1));
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while ((current instanceof CompletionException || current instanceof ExecutionException) && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
     }
 
     @Override
@@ -239,7 +335,12 @@ public class RealWorldGenerator extends ChunkGenerator {
     @Override
     @NotNull
     public List<BlockPopulator> getDefaultPopulators(@NotNull World world) {
-        return singletonList(new TreePopulator(this.customBiomeProvider, yOffset));
+        return this.defaultPopulators;
+    }
+
+    @Override
+    public boolean isParallelCapable() {
+        return true;
     }
 
     @Nullable

--- a/src/main/java/de/btegermany/terraplusminus/gen/tree/TreePopulator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/tree/TreePopulator.java
@@ -14,6 +14,7 @@ import net.buildtheearth.terraminusminus.substitutes.ChunkPos;
 import net.daporkchop.lib.common.reference.ReferenceStrength;
 import net.daporkchop.lib.common.reference.cache.Cached;
 import org.bukkit.Material;
+import org.bukkit.block.Biome;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.generator.LimitedRegion;
 import org.bukkit.generator.WorldInfo;
@@ -136,23 +137,17 @@ public class TreePopulator extends BlockPopulator {
                             int originY = groundY + 1 + yOffset;
                             int originZ = valueZ + z * 16;
                             if (groundY + yOffset < worldInfo.getMaxHeight() - 35 && groundY + yOffset > worldInfo.getMinHeight() && state == null) {
-                                double biomeData = customBiomeProvider.getBiomeData(worldInfo, originX, groundY + yOffset, originZ);
-                                switch ((int) biomeData) {
-                                    case 4, 6, 17: // desert and savanna
-                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "savanna");
-                                        break;
-                                    case 14, 15: // flower forest
-                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
-                                        break;
-                                    case 27: // taiga
-                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "spruce");
-                                        break;
-                                    case 28, 29, 30: // snowy regions
-                                        // TODO: trees with snow
-                                        break;
-                                    default:
-                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
-                                        break;
+                                Biome biome = customBiomeProvider.getBiome(worldInfo, originX, groundY + yOffset, originZ);
+                                if (biome == Biome.DESERT || biome == Biome.SAVANNA || biome == Biome.SAVANNA_PLATEAU) {
+                                    generateCustomTree(limitedRegion, random, originX, originY, originZ, "savanna");
+                                } else if (biome == Biome.FLOWER_FOREST) {
+                                    generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
+                                } else if (biome == Biome.TAIGA) {
+                                    generateCustomTree(limitedRegion, random, originX, originY, originZ, "spruce");
+                                } else if (biome == Biome.SNOWY_SLOPES || biome == Biome.SNOWY_PLAINS || biome == Biome.ICE_SPIKES) {
+                                    // TODO: trees with snow
+                                } else {
+                                    generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
                                 }
                             }
                         }

--- a/src/main/java/de/btegermany/terraplusminus/gen/tree/TreePopulator.java
+++ b/src/main/java/de/btegermany/terraplusminus/gen/tree/TreePopulator.java
@@ -1,7 +1,5 @@
 package de.btegermany.terraplusminus.gen.tree;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.LoadingCache;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -9,18 +7,13 @@ import com.google.gson.stream.JsonReader;
 import de.btegermany.terraplusminus.Terraplusminus;
 import de.btegermany.terraplusminus.gen.CustomBiomeProvider;
 import net.buildtheearth.terraminusminus.generator.CachedChunkData;
-import net.buildtheearth.terraminusminus.generator.ChunkDataLoader;
 import net.buildtheearth.terraminusminus.generator.EarthGeneratorPipelines;
-import net.buildtheearth.terraminusminus.generator.EarthGeneratorSettings;
 import net.buildtheearth.terraminusminus.generator.data.TreeCoverBaker;
 import net.buildtheearth.terraminusminus.substitutes.BlockState;
 import net.buildtheearth.terraminusminus.substitutes.ChunkPos;
 import net.daporkchop.lib.common.reference.ReferenceStrength;
 import net.daporkchop.lib.common.reference.cache.Cached;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.generator.LimitedRegion;
 import org.bukkit.generator.WorldInfo;
@@ -30,22 +23,20 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 
 public class TreePopulator extends BlockPopulator {
 
     public static final Cached<byte[]> RNG_CACHE = Cached.threadLocal(() -> new byte[16 * 16], ReferenceStrength.SOFT);
-    public final LoadingCache<ChunkPos, CompletableFuture<CachedChunkData>> cache;
-    private final EarthGeneratorSettings bteGeneratorSettings = EarthGeneratorSettings.parse(EarthGeneratorSettings.BTE_DEFAULT_SETTINGS);
-    ChunkDataLoader loader = new ChunkDataLoader(bteGeneratorSettings);
-    int xOffset;
+    public final Function<ChunkPos, CompletableFuture<CachedChunkData>> chunkDataProvider;
     int yOffset;
-    int zOffset;
     boolean generateTrees; // Should Trees be added to the Terrain
     String surface;
     CustomBiomeProvider customBiomeProvider;
@@ -54,17 +45,16 @@ public class TreePopulator extends BlockPopulator {
     HashMap<String, ArrayList<ArrayList<TreeBlock>>> trees = new HashMap<>();
 
 
-    public TreePopulator(CustomBiomeProvider customBiomeProvider, int yOffset) {
+    public TreePopulator(
+            CustomBiomeProvider customBiomeProvider,
+            int yOffset,
+            Function<ChunkPos, CompletableFuture<CachedChunkData>> chunkDataProvider
+    ) {
         this.customBiomeProvider = customBiomeProvider;
-        this.xOffset = Terraplusminus.config.getInt("terrain_offset.x");
         this.yOffset = yOffset;
-        this.zOffset = Terraplusminus.config.getInt("terrain_offset.z");
         this.generateTrees = Terraplusminus.config.getBoolean("generate_trees");
         this.surface = Terraplusminus.config.getString("surface_material");
-        this.cache = CacheBuilder.newBuilder()
-                .expireAfterAccess(5L, TimeUnit.MINUTES)
-                .softValues()
-                .build(new ChunkDataLoader(this.bteGeneratorSettings));
+        this.chunkDataProvider = chunkDataProvider;
 
 
         // Load Trees from customTrees.json
@@ -110,21 +100,19 @@ public class TreePopulator extends BlockPopulator {
     }
 
     public void populate(@NotNull WorldInfo worldInfo, @NotNull Random random, int x, int z, @NotNull LimitedRegion limitedRegion) {
-        World world = Bukkit.getWorld(worldInfo.getName());
         if (generateTrees) {
             try {
-                CachedChunkData data = this.loader.load(new ChunkPos(x - (xOffset / 16), z - (zOffset / 16))).get();
+                CachedChunkData data = this.chunkDataProvider.apply(new ChunkPos(x, z)).get();
 
                 byte[] treeCover = data.getCustom(EarthGeneratorPipelines.KEY_DATA_TREE_COVER, TreeCoverBaker.FALLBACK_TREE_DENSITY);
                 byte[] rng = RNG_CACHE.get();
+                random.nextBytes(rng);
 
                 for (int i = 0, dx = 0; dx < 16 >> 1; dx++) {
                     for (int dz = 0; dz < 16 >> 1; dz++, i++) {
-                        if ((rng[i] & 0xFF) < (treeCover[(((x * 16) & 0xF) << 4) | ((z * 16) & 0xF)] & 0xFF)) {
-                            random.nextBytes(rng);
-
-                            int valueX = random.nextInt(15) + 1; // Depending on the size of the tree this should be changed
-                            int valueZ = random.nextInt(15) + 1;
+                        int valueX = random.nextInt(16); // Depending on the size of the tree this should be changed
+                        int valueZ = random.nextInt(16);
+                        if ((rng[i] & 0xFF) < (treeCover[(valueX << 4) | valueZ] & 0xFF)) {
                             int groundY = 0;
                             int waterY = 0;
                             BlockState state = data.surfaceBlock(0, 0);
@@ -144,23 +132,26 @@ public class TreePopulator extends BlockPopulator {
                                 return;
                             }
 
-                            Location loc = new Location(world, valueX + x * 16, groundY + 1 + yOffset, valueZ + z * 16); // is offset missing?
-                            if (!(groundY < waterY) && groundY + yOffset < world.getMaxHeight() - 35 && groundY + yOffset > world.getMinHeight() && state == null) {
-                                switch ((int) customBiomeProvider.getBiome()) {
+                            int originX = valueX + x * 16;
+                            int originY = groundY + 1 + yOffset;
+                            int originZ = valueZ + z * 16;
+                            if (groundY + yOffset < worldInfo.getMaxHeight() - 35 && groundY + yOffset > worldInfo.getMinHeight() && state == null) {
+                                double biomeData = customBiomeProvider.getBiomeData(worldInfo, originX, groundY + yOffset, originZ);
+                                switch ((int) biomeData) {
                                     case 4, 6, 17: // desert and savanna
-                                        generateCustomTree(limitedRegion, loc, "savanna");
+                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "savanna");
                                         break;
                                     case 14, 15: // flower forest
-                                        generateCustomTree(limitedRegion, loc, "oak", "birch");
+                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
                                         break;
                                     case 27: // taiga
-                                        generateCustomTree(limitedRegion, loc, "spruce");
+                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "spruce");
                                         break;
                                     case 28, 29, 30: // snowy regions
                                         // TODO: trees with snow
                                         break;
                                     default:
-                                        generateCustomTree(limitedRegion, loc, "oak", "birch");
+                                        generateCustomTree(limitedRegion, random, originX, originY, originZ, "oak", "birch");
                                         break;
                                 }
                             }
@@ -169,7 +160,15 @@ public class TreePopulator extends BlockPopulator {
                 }
 
 
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Terraplusminus.instance.getComponentLogger().warn(
+                        "Interrupted when generating trees in chunk {}/{} in world {}",
+                        x, z,
+                        worldInfo.getName(),
+                        e
+                );
+            } catch (ExecutionException e) {
                 Terraplusminus.instance.getComponentLogger().warn(
                         "Exception when generating trees in chunk {}/{} in world {}",
                         x, z,
@@ -180,31 +179,12 @@ public class TreePopulator extends BlockPopulator {
         }
     }
 
-    public void generateCustomTree(LimitedRegion limitedRegion, Location loc, String... types) {
-
-        ArrayList<ArrayList<TreeBlock>> trees = new ArrayList<>();
-        for (String type : types) {
-            this.trees.get(type).forEach((tree) -> {
-                trees.add(tree);
-            });
-        }
-
-        // Random Tree
-        if (trees.size() == 0) return;
-
-        int randTree = (new Random()).nextInt(trees.size());
-        if (randTree < 0) randTree = 0;
-        if (randTree > trees.size() - 1) randTree = trees.size() - 1;
-        ArrayList<TreeBlock> tree = trees.get(randTree);
-
-        int originX = loc.getBlockX();
-        int originY = loc.getBlockY();
-        int originZ = loc.getBlockZ();
-
+    public void generateCustomTree(LimitedRegion limitedRegion, Random random, int originX, int originY, int originZ, String... types) {
+        List<TreeBlock> tree = selectTree(random, types);
+        if (tree.isEmpty()) return;
 
         // Rotate Tree Randomly
-        Random rand = new Random();
-        int angle = rand.nextInt(4) * 90;
+        int angle = random.nextInt(4) * 90;
 
         // Place Tree
         for (TreeBlock block : tree) {
@@ -224,6 +204,32 @@ public class TreePopulator extends BlockPopulator {
             }
             limitedRegion.setType(originX + x, originY + block.getY(), originZ + z, block.getMaterial());
         }
+    }
+
+    private List<TreeBlock> selectTree(Random random, String... types) {
+        int totalTrees = 0;
+        for (String type : types) {
+            ArrayList<ArrayList<TreeBlock>> variants = this.trees.get(type);
+            if (variants != null) {
+                totalTrees += variants.size();
+            }
+        }
+        if (totalTrees == 0) {
+            return Collections.emptyList();
+        }
+
+        int selectedTree = random.nextInt(totalTrees);
+        for (String type : types) {
+            ArrayList<ArrayList<TreeBlock>> variants = this.trees.get(type);
+            if (variants == null) {
+                continue;
+            }
+            if (selectedTree < variants.size()) {
+                return variants.get(selectedTree);
+            }
+            selectedTree -= variants.size();
+        }
+        return Collections.emptyList();
     }
 
     public JsonObject getJSONObject() {


### PR DESCRIPTION
## Summary
- add a public Terraplusminus API for checking and priming /tpll target regions
- wait for a 16-chunk-radius Terra-- cache prewarm before standalone /tpll teleports
- add retry/invalidation around failed Terra-- chunk data loads
- bound prewarm concurrency to avoid unbounded Terra-- loader fanout

## Verification
- mvn -q -DskipTests package