### PR TITLE
Re: ✨ add t+-.tpll.newchunks permission node for non-generated chunks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
-import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
     `java-library`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
+import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
     `java-library`
@@ -10,11 +11,8 @@ plugins {
 
 repositories {
     mavenCentral()
-    // mavenLocal() - Only use this for testing if ever
 
-    //maven("https://maven.smyler.net/releases/")
-
-    maven("https://maven.buildtheearth.net/releases") // T-- & Porkchop Lib
+    maven("https://maven.buildtheearth.net/releases")
 
     exclusiveContent {
         forRepository {
@@ -22,8 +20,6 @@ repositories {
                 url = uri("https://repo.papermc.io/repository/maven-public/")
             }
         }
-        // Ensure papermc repo is only used for paper dependencies
-        // Paper also proxies maven central, which has some issues - see https://github.com/PaperMC/Paper/issues/13987
         filter {
             includeGroup("io.papermc")
             includeGroup("io.papermc.paper")
@@ -32,7 +28,7 @@ repositories {
         }
     }
 
-    maven("https://repo.lushplugins.org/releases") // PluginUpdater
+    maven("https://repo.lushplugins.org/releases")
 }
 
 dependencies {
@@ -42,15 +38,15 @@ dependencies {
     paperLibrary(libs.pluginupdater.common) {
         exclude(group = "com.google.guava", module = "guava")
     }
+    paperLibrary(libs.jspecify)
     paperLibrary(libs.pluginupdater.paper)
     compileOnly(libs.paper.api)
-    // Terra+- itself doesn't need Jackson, but we are hitting this JDK bug: https://bugs.openjdk.org/browse/JDK-8305250.
-    // Having a direct compile dependency on Jackson gets rid of the unnecessary warning.
     compileOnly(libs.jackson.databind)
+    compileOnly(libs.jetbrains.annotations)
 }
 
 group = "de.btegermany"
-version = "1.7.0"
+version = "1.7.2-SNAPSHOT"
 description = "A plugin which implements the terra-- api in a paper plugin"
 java.sourceCompatibility = JavaVersion.VERSION_21
 
@@ -67,7 +63,7 @@ paper {
 
     main = "de.btegermany.terraplusminus.Terraplusminus"
 
-    apiVersion = "1.21.4"
+    apiVersion = "1.21"
 
     load = BukkitPluginDescription.PluginLoadOrder.STARTUP
     authors = listOf("meysster", "Nudlsupp", "Nachwahl", "Zoriot")
@@ -75,7 +71,61 @@ paper {
     prefix = "T+-"
 
     loader = "de.btegermany.terraplusminus.PluginLibrariesLoader"
-    generateLibrariesJson = true // https://docs.eldoria.de/pluginyml/libraries/#paper
+    generateLibrariesJson = true
+
+    permissions {
+        register("t+-.admin") {
+            description = "Grants all Terraplusminus permissions"
+            default = BukkitPluginDescription.Permission.Default.OP
+            children = mapOf(
+                "t+-.tpll" to true,
+                "t+-.forcetpll" to true,
+                "t+-.where" to true,
+                "t+-.offset" to true,
+                "t+-.distortion" to true,
+                "t+-.notify.update" to true
+            )
+        }
+        register("t+-.tpll") {
+            description = "Allows usage of /tpll"
+            default = BukkitPluginDescription.Permission.Default.TRUE
+            children = mapOf(
+                "t+-.tpll.ungenerated-chunks" to true
+            )
+        }
+        register("t+-.tpll.ungenerated-chunks") {
+            description = "Allows teleporting to chunks that have not been generated yet"
+            default = BukkitPluginDescription.Permission.Default.TRUE
+        }
+        register("t+-.tpll.otherWorld") {
+            description = "Allows /tpll to resolve a T+- world when the player is in a non-T+- world"
+            default = BukkitPluginDescription.Permission.Default.OP
+        }
+        register("t+-.forcetpll") {
+            description = "Allows force-teleporting other players with /tpll -p"
+            default = BukkitPluginDescription.Permission.Default.OP
+        }
+        register("t+-.where") {
+            description = "Allows usage of /where"
+            default = BukkitPluginDescription.Permission.Default.TRUE
+        }
+        register("t+-.offset") {
+            description = "Allows usage of /offset"
+            default = BukkitPluginDescription.Permission.Default.OP
+        }
+        register("t+-.distortion") {
+            description = "Allows usage of /distortion"
+            default = BukkitPluginDescription.Permission.Default.OP
+        }
+        register("t+-.autoteleport") {
+            description = "Exempts a player from automatic cross-world teleportation on height boundary crossing"
+            default = BukkitPluginDescription.Permission.Default.FALSE
+        }
+        register("t+-.notify.update") {
+            description = "Notifies the player about available plugin updates"
+            default = BukkitPluginDescription.Permission.Default.OP
+        }
+    }
 }
 
 tasks {
@@ -86,7 +136,7 @@ tasks {
 
 tasks.jar {
     archiveClassifier = "UNSHADED"
-    enabled = false // Disable the default jar task since we are using shadowJar
+    enabled = false
 }
 
 tasks.shadowJar {
@@ -98,5 +148,5 @@ tasks.shadowJar {
 }
 
 tasks.assemble {
-    dependsOn(tasks.shadowJar) // Ensure that the shadowJar task runs before the build task
+    dependsOn(tasks.shadowJar)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@ paper-api = "1.21.11-R0.1-SNAPSHOT"
 pluginupdater = "3.0.0"
 # https://maven.smyler.net/#/releases/net/buildtheearth/terraminusminus/terraminusminus-bukkit - use fork which uses daporkchop lib as releases
 terraminusminus = "2.2.1-1.21.8"
+# https://jspecify.dev/docs/
+jspecify = "1.0.0"
+# https://javadoc.io/doc/org.jetbrains/annotations/latest/index.html
+jetbrains-annotations = "26.1.0"
 #
 # Plugins
 #
@@ -32,6 +36,8 @@ paper-api = { module = "io.papermc.paper:paper-api", version.ref = "paper-api" }
 pluginupdater-paper = { module = "org.lushplugins.pluginupdater:updater.paper-api", version.ref = "pluginupdater" }
 pluginupdater-common = { module = "org.lushplugins.pluginupdater:updater.common-api", version.ref = "pluginupdater" }
 terraminusminus = { module = "net.buildtheearth.terraminusminus:terraminusminus-bukkit", version.ref = "terraminusminus" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 [plugins]
 lombok = { id = "io.freefair.lombok", version.ref = "lombok" }

--- a/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
+++ b/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
@@ -155,7 +155,7 @@ public class TpllCommand {
 
         if (!config.getBoolean(Properties.LINKED_WORLDS_ENABLED) && latLngHeight.height() == null) {
             Terraplusminus.instance.getComponentLogger().debug("Fetching elevation from Heightmap...");
-            if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
+            if (!isPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
             finalizeTeleport(target,
                     tpWorld,
                     new Vector(x, tpWorld.getHighestBlockYAt((int) x, (int) z) + 1d, z),
@@ -176,7 +176,7 @@ public class TpllCommand {
             World finalTpWorld = tpWorld;
             terraGenerator.getBaseHeightAsync(chunkX, chunkZ)
                     .thenAcceptAsync(baseHeight -> {
-                        if (!isPlayerPermittedToTeleport(chunkX, chunkZ, finalTpWorld, target)) return;
+                        if (!isPermittedToTeleport(chunkX, chunkZ, finalTpWorld, target)) return;
                         finalizeTeleport(target,
                                 finalTpWorld,
                                 new Vector(x, baseHeight.surfaceHeight(roundedX - ChunkPos.cubeToMinBlock(chunkX),
@@ -190,90 +190,76 @@ public class TpllCommand {
                         return null;
                     });
         } else {
-            if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
+            if (!isPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
             finalizeTeleport(target, tpWorld, new Vector(x, latLngHeight.height() + yOffset, z), latLngHeight.latLng(), yOffset);
         }
     }
 
     /**
-     * Checks whether a player is permitted to teleport to the given chunk coordinates.
+     * Checks whether a player is permitted to teleport to the given chunk.
      * <p>
-     * A player is permitted if:
-     * <ul>
-     *     <li>The destination chunk is already generated in the given world or any of its linked worlds, or</li>
-     *     <li>The player has the {@code t+-.tpll.newchunks} permission</li>
-     * </ul>
-     * If the player is not permitted, a denial message is sent to them and the method returns {@code false}.
+     * Returns {@code true} immediately if the chunk is already generated in any relevant world,
+     * or if the player holds {@code t+-.tpll.ungenerated-chunks}.
+     * Otherwise sends the denial message and returns {@code false}.
      *
-     * @param chunkX The chunk X coordinate of the destination
-     * @param chunkZ The chunk Z coordinate of the destination
-     * @param world  The primary resolved T+- world to check
-     * @param player The player to check permissions for
-     * @return {@code true} if the player may proceed with the teleport, {@code false} otherwise
+     * @param chunkX The chunk X coordinate
+     * @param chunkZ The chunk Z coordinate
+     * @param world  The primary T+- world to check
+     * @param player The player attempting to teleport
+     * @return {@code true} if the teleport may proceed, {@code false} otherwise
      */
-    private static boolean isPlayerPermittedToTeleport(int chunkX, int chunkZ, @NonNull World world, @NonNull Player player) {
+    private static boolean isPermittedToTeleport(int chunkX, int chunkZ, @NonNull World world, @NonNull Player player) {
         if (isChunkGeneratedInAnyRelevantWorld(chunkX, chunkZ, world)) return true;
 
-        if (Permission.TPLL_NEW_CHUNKS.isGrantedTo(player)) return true;
+        if (Permission.TPLL_UNGENERATED_CHUNKS.isGrantedTo(player)) return true;
 
         Terraplusminus.instance.getComponentLogger().debug(
                 "Player {} tried to tpll to an ungenerated chunk ({}, {}) without permission {}",
-                player.getName(), chunkX, chunkZ, Permission.TPLL_NEW_CHUNKS.getNode()
+                player.getName(), chunkX, chunkZ, Permission.TPLL_UNGENERATED_CHUNKS.getNode()
         );
         player.sendMessage(prefix + "§cYou don't have permission to teleport to an ungenerated area.");
         return false;
     }
 
     /**
-     * Checks whether the destination chunk is already generated in at least one relevant world.
+     * Returns {@code true} if the chunk at the given coordinates is already generated in at least one
+     * world that could be the final teleport destination.
      * <p>
-     * For a standard (non-Multiverse) setup, only {@code world} is checked.
-     * For a Multiverse linked worlds setup, all configured linked worlds are checked,
-     * because the final teleport destination may land in a different world depending on the target height.
-     * The chunk is considered generated if it exists in at least one of the linked worlds.
-     *
-     * @param chunkX The chunk X coordinate of the destination
-     * @param chunkZ The chunk Z coordinate of the destination
-     * @param world  The primary resolved T+- world
-     * @return {@code true} if the chunk is generated in at least one relevant world, {@code false} otherwise
+     * For non-Multiverse setups only {@code world} is checked. For Multiverse setups all configured
+     * linked worlds are checked, because the final destination depends on the computed height and may
+     * differ from {@code world}.
      */
     private static boolean isChunkGeneratedInAnyRelevantWorld(int chunkX, int chunkZ, @NonNull World world) {
         FileConfiguration config = Terraplusminus.instance.getConfig();
         boolean isMultiverse = config.getBoolean(Properties.LINKED_WORLDS_ENABLED)
-                && config.getString(Properties.LINKED_WORLDS_METHOD, "")
-                         .equalsIgnoreCase(Properties.NonConfigurable.METHOD_MV);
+                && Properties.NonConfigurable.METHOD_MV.equalsIgnoreCase(
+                        config.getString(Properties.LINKED_WORLDS_METHOD, ""));
 
         if (!isMultiverse) {
-            // Simple case: no linked worlds, just check the main world
             return world.isChunkGenerated(chunkX, chunkZ);
         }
 
-        // Multiverse case: the target height may exceed the current world's bounds and land in another
-        // linked world. We consider the chunk "generated" if it is generated in ANY of the configured
-        // linked worlds, since we cannot know yet which world will be the final destination before
-        // computing the height.
-        List<LinkedWorld> linkedWorlds = ConfigurationHelper.getWorlds();
-        for (LinkedWorld linkedWorld : linkedWorlds) {
-            World bukkitWorld = Bukkit.getWorld(linkedWorld.getWorldName());
-            if (bukkitWorld == null) {
+        for (LinkedWorld linked : ConfigurationHelper.getWorlds()) {
+            World bukkit = Bukkit.getWorld(linked.getWorldName());
+            if (bukkit == null) {
                 Terraplusminus.instance.getComponentLogger().debug(
-                        "Linked world '{}' is configured but not loaded, skipping chunk generation check for it.",
-                        linkedWorld.getWorldName()
+                        "Linked world '{}' is configured but not loaded, skipping chunk generation check.",
+                        linked.getWorldName()
                 );
                 continue;
             }
-            if (bukkitWorld.isChunkGenerated(chunkX, chunkZ)) {
+            if (bukkit.isChunkGenerated(chunkX, chunkZ)) {
                 Terraplusminus.instance.getComponentLogger().debug(
-                        "Chunk ({}, {}) is already generated in linked world '{}'.",
-                        chunkX, chunkZ, linkedWorld.getWorldName()
+                        "Chunk ({}, {}) already generated in linked world '{}'.",
+                        chunkX, chunkZ, linked.getWorldName()
                 );
                 return true;
             }
         }
 
         Terraplusminus.instance.getComponentLogger().debug(
-                "Chunk ({}, {}) is not generated in any of the {} configured linked worlds.",
-                chunkX, chunkZ, linkedWorlds.size()
+                "Chunk ({}, {}) not generated in any of the {} configured linked worlds.",
+                chunkX, chunkZ, ConfigurationHelper.getWorlds().size()
         );
         return false;
     }
@@ -345,8 +331,6 @@ public class TpllCommand {
      * Validates height bounds and teleports the player if within range.
      * <p>
      * Depending on the configuration it uses multiverse worlds or the configured server if the height limit is exceeded.
-     * Also checks whether the player is permitted to teleport to an ungenerated chunk before
-     * performing the actual teleport.
      *
      * @param target    The player to teleport
      * @param tpWorld   The target world
@@ -356,10 +340,6 @@ public class TpllCommand {
      */
     private static void finalizeTeleport(@NonNull Player target, @NonNull World tpWorld, @NonNull Vector mcCoords, LatLng geoCoords, int yOffset) {
         Terraplusminus.instance.getComponentLogger().debug("Current world max height: {}, min height: {}, requested height: {}", tpWorld.getMaxHeight(), tpWorld.getMinHeight(), mcCoords.getBlockY());
-
-        int chunkX = ChunkPos.blockToCube(mcCoords.getBlockX());
-        int chunkZ = ChunkPos.blockToCube(mcCoords.getBlockZ());
-        if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
 
         if (mcCoords.getBlockY() > tpWorld.getMaxHeight()) {
             handleLinkedWorlds(target, true, geoCoords, mcCoords, yOffset);
@@ -381,31 +361,29 @@ public class TpllCommand {
     }
 
     private static boolean getHeightFromMapsAndTeleportIfThere(@NonNull Player target, World tpWorld, LatLongHeight latLngHeight, int yOffset, double x, double z) {
-        var worlds = ConfigurationHelper.getWorlds();
-        for (var world : worlds) {
-            if (world.getWorldName().equalsIgnoreCase(tpWorld.getName())) {
-                World linkedWorld = Bukkit.getWorld(world.getWorldName());
-                if (linkedWorld == null) {
-                    target.sendMessage(prefix + RED + "Linked world not found!");
-                    return false;
-                }
-                int chunkX = ChunkPos.blockToCube((int) Math.round(x));
-                int chunkZ = ChunkPos.blockToCube((int) Math.round(z));
-                if (!linkedWorld.isChunkGenerated(chunkX, chunkZ))
-                    continue;
+        int chunkX = ChunkPos.blockToCube((int) Math.round(x));
+        int chunkZ = ChunkPos.blockToCube((int) Math.round(z));
 
-                Terraplusminus.instance.getComponentLogger().debug("Chunk is already generated, fetching height from Heightmap...");
+        for (LinkedWorld world : ConfigurationHelper.getWorlds()) {
+            if (!world.getWorldName().equalsIgnoreCase(tpWorld.getName())) continue;
 
-                if (!isPlayerPermittedToTeleport(chunkX, chunkZ, linkedWorld, target)) return true;
-
-                int newHeight = tpWorld.getHighestBlockYAt((int) x, (int) z) + 1;
-                finalizeTeleport(target,
-                        linkedWorld,
-                        new Vector(x, newHeight, z),
-                        latLngHeight.latLng(),
-                        yOffset);
-                return true;
+            World linkedWorld = Bukkit.getWorld(world.getWorldName());
+            if (linkedWorld == null) {
+                target.sendMessage(prefix + RED + "Linked world not found!");
+                return false;
             }
+            if (!linkedWorld.isChunkGenerated(chunkX, chunkZ)) continue;
+
+            Terraplusminus.instance.getComponentLogger().debug("Chunk is already generated, fetching height from Heightmap...");
+
+            if (!isPermittedToTeleport(chunkX, chunkZ, linkedWorld, target)) return true;
+
+            finalizeTeleport(target,
+                    linkedWorld,
+                    new Vector(x, tpWorld.getHighestBlockYAt((int) x, (int) z) + 1, z),
+                    latLngHeight.latLng(),
+                    yOffset);
+            return true;
         }
         return false;
     }
@@ -438,12 +416,9 @@ public class TpllCommand {
         Terraplusminus plugin = (Terraplusminus) JavaPlugin.getProvidingPlugin(Terraplusminus.class);
         ByteArrayDataOutput out = ByteStreams.newDataOutput();
         out.writeUTF(player.getUniqueId().toString());
-        LinkedWorld server;
-        if (isNextServer) {
-            server = ConfigurationHelper.getNextServerName(plugin.getRegisteredServerName());
-        } else {
-            server = ConfigurationHelper.getPreviousServerName(plugin.getRegisteredServerName());
-        }
+        LinkedWorld server = isNextServer
+                ? ConfigurationHelper.getNextServerName(plugin.getRegisteredServerName())
+                : ConfigurationHelper.getPreviousServerName(plugin.getRegisteredServerName());
 
         if (server != null) {
             out.writeUTF(server.getWorldName() + ", " + server.getOffset());
@@ -453,7 +428,6 @@ public class TpllCommand {
         }
         out.writeUTF(geoCoords.getLat() + ", " + geoCoords.getLng());
         player.sendPluginMessage(plugin, Properties.NonConfigurable.CROSS_TELEPORTATION_CHANNEL, out.toByteArray());
-
         player.sendMessage(prefix + "§cSending to another server...");
     }
     // </editor-fold>
@@ -475,6 +449,12 @@ public class TpllCommand {
     public static LiteralCommandNode<CommandSourceStack> create() {
         prefix = Terraplusminus.instance.getConfig().getString(Properties.CHAT_PREFIX);
 
+        // Structure:
+        // /tpll <coords>                       -> self teleport
+        // /tpll -p <players> <coords>          -> force teleport (uses Brigadier player selector)
+        //
+        // Using a literal "-p" prefix avoids Brigadier trying to parse coordinates as player selectors.
+        // This is the cleanest solution that works reliably with Brigadier.
         return Commands.literal("tpll")
                 .then(Commands.literal("-p")
                         .requires(source -> Permission.FORCETPLL_CMD.isGrantedTo(source.getSender()))
@@ -565,7 +545,6 @@ public class TpllCommand {
 
         String[] argsArray = args.split(" ");
 
-        // Try parsing coordinates with height at the end (need at least 3 parts: lat, lon, height)
         if (argsArray.length >= 3) {
             String possibleHeight = argsArray[argsArray.length - 1];
             Terraplusminus.instance.getComponentLogger().debug("Possible height: '{}'", possibleHeight);
@@ -579,7 +558,6 @@ public class TpllCommand {
             }
         }
 
-        // Try parsing the full string as coordinates (no height specified)
         LatLng latLng = CoordinateParseUtils.parseVerbatimCoordinates(args);
         if (latLng != null) {
             return new LatLongHeight(latLng, null);
@@ -588,9 +566,6 @@ public class TpllCommand {
         return new LatLongHeight(null, null);
     }
 
-    /**
-     * Tries to parse a string as a double, returns null if parsing fails.
-     */
     @Contract(pure = true)
     private static @Nullable Double tryParseDouble(String value) {
         try {

--- a/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
+++ b/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
@@ -77,6 +77,8 @@ public class TpllCommand {
      *     <li>Validates the world is a Terraplusminus world</li>
      *     <li>Parses the coordinates from the arguments</li>
      *     <li>Checks boundary restrictions</li>
+     *     <li>Checks if the destination chunk is already generated when the player lacks
+     *         {@code t+-.tpll.newchunks}, considering all linked Multiverse worlds when applicable</li>
      *     <li>Handles cross-world teleportation if needed</li>
      *     <li>Performs the actual teleport</li>
      * </ol>
@@ -117,6 +119,7 @@ public class TpllCommand {
         } else {
             terraGenerator = tg;
         }
+
         EarthGeneratorSettings generatorSettings = terraGenerator.getSettings();
         GeographicProjection projection = generatorSettings.projection();
         LatLongHeight latLngHeight = parseArguments(args);
@@ -144,6 +147,20 @@ public class TpllCommand {
                 (latLngHeight.latLng().getLat() < minLat || latLngHeight.latLng().getLng() < minLon || latLngHeight.latLng().getLat() > maxLat || latLngHeight.latLng().getLng() > maxLon)) {
             sender.sendMessage(prefix + "§cYou cannot tpll to these coordinates, because this area is being worked on by another build team.");
             return;
+        }
+
+        if (!Permission.TPLL_NEW_CHUNKS.isGrantedTo(sender)) {
+            int destinationChunkX = ChunkPos.blockToCube((int) Math.round(x));
+            int destinationChunkZ = ChunkPos.blockToCube((int) Math.round(z));
+
+            if (!isChunkGeneratedInAnyRelevantWorld(tpWorld, destinationChunkX, destinationChunkZ, config)) {
+                Terraplusminus.instance.getComponentLogger().debug(
+                        "Player {} tried to tpll to an ungenerated chunk ({}, {}) without permission {}",
+                        target.getName(), destinationChunkX, destinationChunkZ, Permission.TPLL_NEW_CHUNKS.getNode()
+                );
+                sender.sendMessage(prefix + "§cYou don't have permission to teleport to an ungenerated area.");
+                return;
+            }
         }
 
         int yOffset = terraGenerator.getYOffset();
@@ -188,6 +205,62 @@ public class TpllCommand {
         } else {
             finalizeTeleport(target, tpWorld, new Vector(x, latLngHeight.height() + yOffset, z), latLngHeight.latLng(), yOffset);
         }
+    }
+
+    /**
+     * Checks whether the destination chunk is already generated in at least one relevant world.
+     * <p>
+     * For a standard (non-Multiverse) setup, only {@code tpWorld} is checked.
+     * For a Multiverse linked worlds setup, all configured linked worlds are checked,
+     * because the final teleport destination may land in a different world depending on the target height.
+     * The chunk is considered generated if it exists in at least one of the linked worlds.
+     *
+     * @param tpWorld           The primary resolved T+- world
+     * @param destinationChunkX The chunk X coordinate of the destination
+     * @param destinationChunkZ The chunk Z coordinate of the destination
+     * @param config            The plugin configuration
+     * @return {@code true} if the chunk is generated in at least one relevant world, {@code false} otherwise
+     */
+    private static boolean isChunkGeneratedInAnyRelevantWorld(@NonNull World tpWorld,
+                                                               int destinationChunkX,
+                                                               int destinationChunkZ,
+                                                               @NonNull FileConfiguration config) {
+        boolean isMultiverse = config.getBoolean(Properties.LINKED_WORLDS_ENABLED)
+                && config.getString(Properties.LINKED_WORLDS_METHOD, "")
+                         .equalsIgnoreCase(Properties.NonConfigurable.METHOD_MV);
+
+        if (!isMultiverse) {
+            // Simple case: no linked worlds, just check the main world
+            return tpWorld.isChunkGenerated(destinationChunkX, destinationChunkZ);
+        }
+
+        // Multiverse case: the target height may exceed tpWorld's bounds and land in another linked world.
+        // We consider the chunk "generated" if it is generated in ANY of the configured linked worlds,
+        // since we cannot know yet which world will be the final destination before computing the height.
+        List<LinkedWorld> linkedWorlds = ConfigurationHelper.getWorlds();
+        for (LinkedWorld linkedWorld : linkedWorlds) {
+            World bukkitWorld = Bukkit.getWorld(linkedWorld.getWorldName());
+            if (bukkitWorld == null) {
+                Terraplusminus.instance.getComponentLogger().debug(
+                        "Linked world '{}' is configured but not loaded, skipping chunk generation check for it.",
+                        linkedWorld.getWorldName()
+                );
+                continue;
+            }
+            if (bukkitWorld.isChunkGenerated(destinationChunkX, destinationChunkZ)) {
+                Terraplusminus.instance.getComponentLogger().debug(
+                        "Chunk ({}, {}) is already generated in linked world '{}'.",
+                        destinationChunkX, destinationChunkZ, linkedWorld.getWorldName()
+                );
+                return true;
+            }
+        }
+
+        Terraplusminus.instance.getComponentLogger().debug(
+                "Chunk ({}, {}) is not generated in any of the {} configured linked worlds.",
+                destinationChunkX, destinationChunkZ, linkedWorlds.size()
+        );
+        return false;
     }
 
     /**
@@ -510,7 +583,7 @@ public class TpllCommand {
     }
 
     /**
-     * Gets all objects in a string array under a given index
+     * Gets all objects in a string array under a given index.
      * Example: {@code inverseSelectArray(["a", "b", "c"], 2)} → {@code ["a", "b"]}
      *
      * @param args    Initial array

--- a/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
+++ b/src/main/java/de/btegermany/terraplusminus/commands/TpllCommand.java
@@ -77,8 +77,6 @@ public class TpllCommand {
      *     <li>Validates the world is a Terraplusminus world</li>
      *     <li>Parses the coordinates from the arguments</li>
      *     <li>Checks boundary restrictions</li>
-     *     <li>Checks if the destination chunk is already generated when the player lacks
-     *         {@code t+-.tpll.newchunks}, considering all linked Multiverse worlds when applicable</li>
      *     <li>Handles cross-world teleportation if needed</li>
      *     <li>Performs the actual teleport</li>
      * </ol>
@@ -132,8 +130,8 @@ public class TpllCommand {
         double x;
         double z;
         try {
-            double[] mcCoordinates = projection.fromGeo(latLngHeight.latLng().getLng(), latLngHeight.latLng().getLat()); // projection.fromGeo is eccentric and expects lon, lat
-            x = mcCoordinates[0]; // These Coordinates already contains the configured offsets
+            double[] mcCoordinates = projection.fromGeo(latLngHeight.latLng().getLng(), latLngHeight.latLng().getLat());
+            x = mcCoordinates[0];
             z = mcCoordinates[1];
         } catch (OutOfProjectionBoundsException e) {
             sender.sendMessage(prefix + "§cLocation is not within projection bounds.");
@@ -149,24 +147,15 @@ public class TpllCommand {
             return;
         }
 
-        if (!Permission.TPLL_NEW_CHUNKS.isGrantedTo(sender)) {
-            int destinationChunkX = ChunkPos.blockToCube((int) Math.round(x));
-            int destinationChunkZ = ChunkPos.blockToCube((int) Math.round(z));
-
-            if (!isChunkGeneratedInAnyRelevantWorld(tpWorld, destinationChunkX, destinationChunkZ, config)) {
-                Terraplusminus.instance.getComponentLogger().debug(
-                        "Player {} tried to tpll to an ungenerated chunk ({}, {}) without permission {}",
-                        target.getName(), destinationChunkX, destinationChunkZ, Permission.TPLL_NEW_CHUNKS.getNode()
-                );
-                sender.sendMessage(prefix + "§cYou don't have permission to teleport to an ungenerated area.");
-                return;
-            }
-        }
-
         int yOffset = terraGenerator.getYOffset();
+        int roundedX = (int) Math.round(x);
+        int roundedZ = (int) Math.round(z);
+        int chunkX = ChunkPos.blockToCube(roundedX);
+        int chunkZ = ChunkPos.blockToCube(roundedZ);
 
         if (!config.getBoolean(Properties.LINKED_WORLDS_ENABLED) && latLngHeight.height() == null) {
             Terraplusminus.instance.getComponentLogger().debug("Fetching elevation from Heightmap...");
+            if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
             finalizeTeleport(target,
                     tpWorld,
                     new Vector(x, tpWorld.getHighestBlockYAt((int) x, (int) z) + 1d, z),
@@ -184,59 +173,85 @@ public class TpllCommand {
 
         if (latLngHeight.height() == null) {
             Terraplusminus.instance.getComponentLogger().debug("Fetching elevation from API...");
-            int roundedX = (int) Math.round(x);
-            int roundedZ = (int) Math.round(z);
-            int chunkX = ChunkPos.blockToCube(roundedX);
-            int chunkZ = ChunkPos.blockToCube(roundedZ);
             World finalTpWorld = tpWorld;
             terraGenerator.getBaseHeightAsync(chunkX, chunkZ)
-                    .thenAcceptAsync(baseHeight ->
-                            finalizeTeleport(target,
-                                    finalTpWorld,
-                                    new Vector(x, baseHeight.surfaceHeight(roundedX - ChunkPos.cubeToMinBlock(chunkX),
-                                            roundedZ - ChunkPos.cubeToMinBlock(chunkZ)) + yOffset + 1d, z),
-                                    latLngHeight.latLng(),
-                                    yOffset
-                            )).exceptionally(ex -> {
+                    .thenAcceptAsync(baseHeight -> {
+                        if (!isPlayerPermittedToTeleport(chunkX, chunkZ, finalTpWorld, target)) return;
+                        finalizeTeleport(target,
+                                finalTpWorld,
+                                new Vector(x, baseHeight.surfaceHeight(roundedX - ChunkPos.cubeToMinBlock(chunkX),
+                                        roundedZ - ChunkPos.cubeToMinBlock(chunkZ)) + yOffset + 1d, z),
+                                latLngHeight.latLng(),
+                                yOffset
+                        );
+                    }).exceptionally(ex -> {
                         target.sendMessage(RED + "Error while fetching elevation from API!");
                         Terraplusminus.instance.getComponentLogger().error("Error while fetching elevation from API for tpll!", ex);
                         return null;
                     });
         } else {
+            if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
             finalizeTeleport(target, tpWorld, new Vector(x, latLngHeight.height() + yOffset, z), latLngHeight.latLng(), yOffset);
         }
     }
 
     /**
+     * Checks whether a player is permitted to teleport to the given chunk coordinates.
+     * <p>
+     * A player is permitted if:
+     * <ul>
+     *     <li>The destination chunk is already generated in the given world or any of its linked worlds, or</li>
+     *     <li>The player has the {@code t+-.tpll.newchunks} permission</li>
+     * </ul>
+     * If the player is not permitted, a denial message is sent to them and the method returns {@code false}.
+     *
+     * @param chunkX The chunk X coordinate of the destination
+     * @param chunkZ The chunk Z coordinate of the destination
+     * @param world  The primary resolved T+- world to check
+     * @param player The player to check permissions for
+     * @return {@code true} if the player may proceed with the teleport, {@code false} otherwise
+     */
+    private static boolean isPlayerPermittedToTeleport(int chunkX, int chunkZ, @NonNull World world, @NonNull Player player) {
+        if (isChunkGeneratedInAnyRelevantWorld(chunkX, chunkZ, world)) return true;
+
+        if (Permission.TPLL_NEW_CHUNKS.isGrantedTo(player)) return true;
+
+        Terraplusminus.instance.getComponentLogger().debug(
+                "Player {} tried to tpll to an ungenerated chunk ({}, {}) without permission {}",
+                player.getName(), chunkX, chunkZ, Permission.TPLL_NEW_CHUNKS.getNode()
+        );
+        player.sendMessage(prefix + "§cYou don't have permission to teleport to an ungenerated area.");
+        return false;
+    }
+
+    /**
      * Checks whether the destination chunk is already generated in at least one relevant world.
      * <p>
-     * For a standard (non-Multiverse) setup, only {@code tpWorld} is checked.
+     * For a standard (non-Multiverse) setup, only {@code world} is checked.
      * For a Multiverse linked worlds setup, all configured linked worlds are checked,
      * because the final teleport destination may land in a different world depending on the target height.
      * The chunk is considered generated if it exists in at least one of the linked worlds.
      *
-     * @param tpWorld           The primary resolved T+- world
-     * @param destinationChunkX The chunk X coordinate of the destination
-     * @param destinationChunkZ The chunk Z coordinate of the destination
-     * @param config            The plugin configuration
+     * @param chunkX The chunk X coordinate of the destination
+     * @param chunkZ The chunk Z coordinate of the destination
+     * @param world  The primary resolved T+- world
      * @return {@code true} if the chunk is generated in at least one relevant world, {@code false} otherwise
      */
-    private static boolean isChunkGeneratedInAnyRelevantWorld(@NonNull World tpWorld,
-                                                               int destinationChunkX,
-                                                               int destinationChunkZ,
-                                                               @NonNull FileConfiguration config) {
+    private static boolean isChunkGeneratedInAnyRelevantWorld(int chunkX, int chunkZ, @NonNull World world) {
+        FileConfiguration config = Terraplusminus.instance.getConfig();
         boolean isMultiverse = config.getBoolean(Properties.LINKED_WORLDS_ENABLED)
                 && config.getString(Properties.LINKED_WORLDS_METHOD, "")
                          .equalsIgnoreCase(Properties.NonConfigurable.METHOD_MV);
 
         if (!isMultiverse) {
             // Simple case: no linked worlds, just check the main world
-            return tpWorld.isChunkGenerated(destinationChunkX, destinationChunkZ);
+            return world.isChunkGenerated(chunkX, chunkZ);
         }
 
-        // Multiverse case: the target height may exceed tpWorld's bounds and land in another linked world.
-        // We consider the chunk "generated" if it is generated in ANY of the configured linked worlds,
-        // since we cannot know yet which world will be the final destination before computing the height.
+        // Multiverse case: the target height may exceed the current world's bounds and land in another
+        // linked world. We consider the chunk "generated" if it is generated in ANY of the configured
+        // linked worlds, since we cannot know yet which world will be the final destination before
+        // computing the height.
         List<LinkedWorld> linkedWorlds = ConfigurationHelper.getWorlds();
         for (LinkedWorld linkedWorld : linkedWorlds) {
             World bukkitWorld = Bukkit.getWorld(linkedWorld.getWorldName());
@@ -247,10 +262,10 @@ public class TpllCommand {
                 );
                 continue;
             }
-            if (bukkitWorld.isChunkGenerated(destinationChunkX, destinationChunkZ)) {
+            if (bukkitWorld.isChunkGenerated(chunkX, chunkZ)) {
                 Terraplusminus.instance.getComponentLogger().debug(
                         "Chunk ({}, {}) is already generated in linked world '{}'.",
-                        destinationChunkX, destinationChunkZ, linkedWorld.getWorldName()
+                        chunkX, chunkZ, linkedWorld.getWorldName()
                 );
                 return true;
             }
@@ -258,7 +273,7 @@ public class TpllCommand {
 
         Terraplusminus.instance.getComponentLogger().debug(
                 "Chunk ({}, {}) is not generated in any of the {} configured linked worlds.",
-                destinationChunkX, destinationChunkZ, linkedWorlds.size()
+                chunkX, chunkZ, linkedWorlds.size()
         );
         return false;
     }
@@ -330,6 +345,8 @@ public class TpllCommand {
      * Validates height bounds and teleports the player if within range.
      * <p>
      * Depending on the configuration it uses multiverse worlds or the configured server if the height limit is exceeded.
+     * Also checks whether the player is permitted to teleport to an ungenerated chunk before
+     * performing the actual teleport.
      *
      * @param target    The player to teleport
      * @param tpWorld   The target world
@@ -338,8 +355,11 @@ public class TpllCommand {
      * @param yOffset   The configured terrain offset
      */
     private static void finalizeTeleport(@NonNull Player target, @NonNull World tpWorld, @NonNull Vector mcCoords, LatLng geoCoords, int yOffset) {
-
         Terraplusminus.instance.getComponentLogger().debug("Current world max height: {}, min height: {}, requested height: {}", tpWorld.getMaxHeight(), tpWorld.getMinHeight(), mcCoords.getBlockY());
+
+        int chunkX = ChunkPos.blockToCube(mcCoords.getBlockX());
+        int chunkZ = ChunkPos.blockToCube(mcCoords.getBlockZ());
+        if (!isPlayerPermittedToTeleport(chunkX, chunkZ, tpWorld, target)) return;
 
         if (mcCoords.getBlockY() > tpWorld.getMaxHeight()) {
             handleLinkedWorlds(target, true, geoCoords, mcCoords, yOffset);
@@ -369,10 +389,14 @@ public class TpllCommand {
                     target.sendMessage(prefix + RED + "Linked world not found!");
                     return false;
                 }
-                if (!linkedWorld.isChunkGenerated(ChunkPos.blockToCube((int) Math.round(x)), ChunkPos.blockToCube((int) Math.round(z))))
+                int chunkX = ChunkPos.blockToCube((int) Math.round(x));
+                int chunkZ = ChunkPos.blockToCube((int) Math.round(z));
+                if (!linkedWorld.isChunkGenerated(chunkX, chunkZ))
                     continue;
 
                 Terraplusminus.instance.getComponentLogger().debug("Chunk is already generated, fetching height from Heightmap...");
+
+                if (!isPlayerPermittedToTeleport(chunkX, chunkZ, linkedWorld, target)) return true;
 
                 int newHeight = tpWorld.getHighestBlockYAt((int) x, (int) z) + 1;
                 finalizeTeleport(target,
@@ -451,15 +475,9 @@ public class TpllCommand {
     public static LiteralCommandNode<CommandSourceStack> create() {
         prefix = Terraplusminus.instance.getConfig().getString(Properties.CHAT_PREFIX);
 
-        // Structure:
-        // /tpll <coords>                       -> self teleport
-        // /tpll -p <players> <coords>          -> force teleport (uses Brigadier player selector)
-        //
-        // Using a literal "-p" prefix avoids Brigadier trying to parse coordinates as player selectors.
-        // This is the cleanest solution that works reliably with Brigadier.
         return Commands.literal("tpll")
                 .then(Commands.literal("-p")
-                        .requires(source -> Permission.ADMIN.isGrantedTo(source.getSender()))
+                        .requires(source -> Permission.FORCETPLL_CMD.isGrantedTo(source.getSender()))
                         .then(Commands.argument("players", ArgumentTypes.players())
                                 .then(Commands.argument(LAT_LON_HEIGHT, StringArgumentType.greedyString())
                                         .executes(TpllCommand::executeTarget)
@@ -514,15 +532,15 @@ public class TpllCommand {
      * Checks for {@code t+-.forcetpll} or {@code t+-.tpll} (if self-teleporting).
      */
     private static boolean isPermitted(@NonNull CommandSourceStack source) {
-        return Permission.ADMIN.isGrantedTo(source.getSender()) ||
-                (source.getSender() == source.getExecutor() && Permission.TPLL_OTHER_WORLD_CMD.isGrantedTo(source.getSender()));
+        return Permission.FORCETPLL_CMD.isGrantedTo(source.getSender()) ||
+                (source.getSender() == source.getExecutor() && Permission.TPLL_CMD.isGrantedTo(source.getSender()));
     }
 
     /**
      * Checks for {@code t+-.forcetpll} permission.
      */
     private static boolean isPermittedTarget(@NonNull CommandSourceStack commandSourceStack) {
-        return Permission.ADMIN.isGrantedTo(commandSourceStack.getSender());
+        return Permission.FORCETPLL_CMD.isGrantedTo(commandSourceStack.getSender());
     }
     // </editor-fold>
 

--- a/src/main/java/de/btegermany/terraplusminus/utils/Permission.java
+++ b/src/main/java/de/btegermany/terraplusminus/utils/Permission.java
@@ -11,6 +11,7 @@ public enum Permission {
     WHERE_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "where"),
     TPLL_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "tpll"),
     TPLL_OTHER_WORLD_CMD(TPLL_CMD.node + ".otherWorld"),
+    TPLL_NEW_CHUNKS(TPLL_CMD.node + ".newchunks"),
     FORCETPLL_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "forcetpll"),
     ADMIN(Properties.NonConfigurable.PERMISSION_PREFIX + "admin"),
     AUTOTELEPORT(Properties.NonConfigurable.PERMISSION_PREFIX + "autoteleport"),

--- a/src/main/java/de/btegermany/terraplusminus/utils/Permission.java
+++ b/src/main/java/de/btegermany/terraplusminus/utils/Permission.java
@@ -11,7 +11,7 @@ public enum Permission {
     WHERE_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "where"),
     TPLL_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "tpll"),
     TPLL_OTHER_WORLD_CMD(TPLL_CMD.node + ".otherWorld"),
-    TPLL_NEW_CHUNKS(TPLL_CMD.node + ".newchunks"),
+    TPLL_UNGENERATED_CHUNKS(TPLL_CMD.node + ".ungenerated-chunks"),
     FORCETPLL_CMD(Properties.NonConfigurable.PERMISSION_PREFIX + "forcetpll"),
     ADMIN(Properties.NonConfigurable.PERMISSION_PREFIX + "admin"),
     AUTOTELEPORT(Properties.NonConfigurable.PERMISSION_PREFIX + "autoteleport"),


### PR DESCRIPTION
Implements the permission node `t+-.tpll.newchunks` requested in #74.
Players without this permission can still use `/tpll` to already-generated areas, but cannot trigger new chunk generation. Useful for servers where Visitors should be able to navigate built areas without accidentally loading new terrain.

## Changes

- Added `TPLL_NEW_CHUNKS` to `Permission.java`
- Added chunk generation check in `TpllCommand#execute()` using `World#isChunkGenerated()`
- For Multiverse setups, the check spans all linked worlds since the final destination world is not yet known at that point

## Permission

| Node | Default | Description |
|------|---------|-------------|
| `t+-.tpll.newchunks` | `false` | Allows `/tpll` to ungenerated chunks |

## Notes

- Admins (`t+-.admin`) bypass the check implicitly via their permission setup
- The Multiverse multi-world check is necessary because before height resolution, we don't know which linked world will be the final destination, so we accept the teleport if the chunk exists in any of them